### PR TITLE
Blocks horizontal scrolling for carousel slider

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -37751,6 +37751,11 @@ footer.bg-dark.angled.upper-start:before {
   cursor:pointer;
 }
 
+#integrations {
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
 @keyframes scroll {
   0% {
     transform: translateX(0px);


### PR DESCRIPTION
Disable horizontal scrolling for carousel slider (it was provoking weird experience on safari).

The result can be temporarily be checked [here](https://a43c-176-162-58-252.eu.ngrok.io/).